### PR TITLE
Refactor FlyreelSDKReactNative to Flyreel, ReadMe Tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ permission settings in your Info.plist file.
 </dict>
 ```
 
+### Importing
+
+To use the Flyreel SDK, import it into your javascript or typescript files like so: 
+
+```TS
+import Flyreel from 'flyreel-sdk-react-native'
+```
+
+
 ### Initialization
 
 To use the Flyreel SDK, you must provide a configuration with the following parameters:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,24 @@
 import { NativeModules, Platform } from 'react-native';
 
+type FlyreelSDKType = {
+  initialize(organizationId: String, settingsVersion: number): Promise<void>;
+  initializeWithSandbox(
+    organizationId: String,
+    settingsVersion: number
+  ): Promise<void>;
+  open(): Promise<void>;
+  openWithDeeplink(
+    deeplinkUrl: String,
+    shouldSkipLoginPage: Boolean
+  ): Promise<void>;
+  openWithCredentials(
+    zipCode: String,
+    accessCode: String,
+    shouldSkipLoginPage: boolean
+  ): Promise<void>;
+  enableLogs(): Promise<void>;
+};
+
 const LINKING_ERROR =
   `The package 'flyreel-sdk-react-native' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
@@ -17,4 +36,4 @@ const Flyreel = NativeModules.Flyreel
       }
     );
 
-export default Flyreel;
+export default Flyreel as FlyreelSDKType;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import { NativeModules, Platform } from 'react-native';
-// const {Flyreel} = NativeModules;
 
 const LINKING_ERROR =
   `The package 'flyreel-sdk-react-native' doesn't seem to be linked. Make sure: \n\n` +

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ type FlyreelSDKType = {
   open(): Promise<void>;
   openWithDeeplink(
     deeplinkUrl: String,
-    shouldSkipLoginPage: Boolean
+    shouldSkipLoginPage: boolean
   ): Promise<void>;
   openWithCredentials(
     zipCode: String,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,6 @@ const Flyreel = NativeModules.Flyreel
           throw new Error(LINKING_ERROR);
         },
       }
-  );
+    );
 
 export default Flyreel;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { NativeModules, Platform } from 'react-native';
+// const {Flyreel} = NativeModules;
 
 const LINKING_ERROR =
   `The package 'flyreel-sdk-react-native' doesn't seem to be linked. Make sure: \n\n` +
@@ -6,8 +7,8 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
 
-const FlyreelSdkReactNative = NativeModules.FlyreelSdkReactNative
-  ? NativeModules.FlyreelSdkReactNative
+const Flyreel = NativeModules.Flyreel
+  ? NativeModules.Flyreel
   : new Proxy(
       {},
       {
@@ -15,8 +16,6 @@ const FlyreelSdkReactNative = NativeModules.FlyreelSdkReactNative
           throw new Error(LINKING_ERROR);
         },
       }
-    );
+  );
 
-export function multiply(a: number, b: number): Promise<number> {
-  return FlyreelSdkReactNative.multiply(a, b);
-}
+export default Flyreel;


### PR DESCRIPTION
Hello All, 

This ticket is based on what I found when trying to install the sdk package on an Standalone React Native Application. 

I noticed that we were not using the multiply function, as it came with the code generations script, and removed that from what's being exported in the module. 

I also had to rename the const FlyreelSdkReactNative to Flyreel to match the commands found in the ReadMe before this branch creation. Then I exported that Flyreel const so it can be used elsewhere. 

Also readme has been tweaked to show how to import the package. 

Let me know if these changes are unnecessary, this is just what I found in my testing. 

I'll merge and republish after input from the team. 